### PR TITLE
add Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787001381,
+        "narHash": "sha256-Ue1Yo8gfHdD4TMtNewhA4tkSYeFqXThju0nCyJc3ALo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ec2d622de0773551768cf98f3fc50cbcc003b9c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A modern desktop client for Jellyfin, with an optional built-in YouTube player and Seerr requests.";
+  description = "A modern desktop client for Jellyfin, with an optional built-in YouTube player and Seerr requests";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
@@ -27,6 +27,17 @@
         '';
       });
     }) inputs.nixpkgs.legacyPackages;
+
+    apps =
+      let
+        mkApp = system: {
+          fathom = {
+            type = "app";
+            program = "${inputs.self.packages.${system}.fathom}/bin/fathom";
+          };
+        };
+      in
+      builtins.mapAttrs (system: pkgs: mkApp system) inputs.nixpkgs.legacyPackages;
 
     overlays.default = final: prev: {
       fathom = inputs.self.packages.${final.system}.fathom;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = "A modern desktop client for Jellyfin, with an optional built-in YouTube player and Seerr requests.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = inputs: {
+    packages = builtins.mapAttrs (system: pkgs: rec {
+      default = fathom;
+
+      fathom = pkgs.flutter344.buildFlutterApplication (finalAttrs: {
+        pname = "fathom";
+        version = "0.11.1";
+
+        src = ./.;
+
+        buildInputs = with pkgs; [ mpv ];
+
+        autoPubspecLock = ./pubspec.lock;
+
+        postInstall = ''
+          install -Dm644 ${finalAttrs.src}/linux/packaging/icons/fathom-512.png $out/share/icons/hicolor/512x512/apps/app.fathom.player.png
+          install -Dm644 ${finalAttrs.src}/linux/packaging/icons/fathom-256.png $out/share/icons/hicolor/256x256/apps/app.fathom.player.png
+          install -Dm644 ${finalAttrs.src}/linux/packaging/icons/fathom-128.png $out/share/icons/hicolor/128x128/apps/app.fathom.player.png
+          install -Dm644 ${finalAttrs.src}/linux/packaging/app.fathom.player.desktop $out/share/applications/fathom.desktop
+        '';
+      });
+    }) inputs.nixpkgs.legacyPackages;
+
+    overlays.default = final: prev: {
+      fathom = inputs.self.packages.${final.system}.fathom;
+    };
+
+    devShells = builtins.mapAttrs (system: pkgs: {
+      default = pkgs.mkShell {
+        packages = with pkgs; [
+          flutter344
+          dart
+        ];
+      };
+    }) inputs.nixpkgs.legacyPackages;
+  };
+}


### PR DESCRIPTION
This PR adds a flake for the Nix package manager. You problably don't use it but it makes it possiblef or people using it to test fathom with a single command:

```sh
nix run github:Fathom-Media/fathom
```

More information about Flakes can be seen [here](https://nixos-and-flakes.thiscute.world/nixos-with-flakes/introduction-to-flakes).