### PR TITLE
Storage: fall back to a local unencrypted store when the system secret service is entirely unavailable (#32)

### DIFF
--- a/lib/data/accounts_store.dart
+++ b/lib/data/accounts_store.dart
@@ -1,8 +1,7 @@
 import 'dart:convert';
 
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-
 import '../models/session.dart';
+import '../services/resilient_secure_storage.dart';
 
 /// Stable per-account identity. Keys on the server id (which survives an
 /// internal/external address swap) plus the user, so the active [Session.baseUrl]
@@ -34,7 +33,7 @@ class Accounts {
 class AccountsStore {
   static const _key = 'fathom_accounts';
   static const _legacyKey = 'fathom_session';
-  final FlutterSecureStorage _storage;
+  final ResilientSecureStorage _storage;
 
   AccountsStore(this._storage);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:uuid/uuid.dart';
 import 'package:window_manager/window_manager.dart';
@@ -18,6 +17,7 @@ import 'services/app_installer.dart';
 import 'services/desktop_integration.dart';
 import 'services/diagnostics.dart';
 import 'services/notifications.dart';
+import 'services/resilient_secure_storage.dart';
 import 'state/audio_handler.dart';
 import 'state/providers.dart';
 
@@ -100,7 +100,7 @@ Future<void> main() async {
   // sit in storage. Fire-and-forget — never blocks launch.
   unawaited(cleanUpdateArtifacts());
 
-  const storage = FlutterSecureStorage();
+  const storage = ResilientSecureStorage();
   final deviceId = await _getOrCreateDeviceId(storage);
 
   // Mobile-only: bring up the OS media session for background music + a
@@ -153,7 +153,7 @@ Future<void> main() async {
   );
 }
 
-Future<String> _getOrCreateDeviceId(FlutterSecureStorage storage) async {
+Future<String> _getOrCreateDeviceId(ResilientSecureStorage storage) async {
   const key = 'fathom_device_id';
   var id = await storage.read(key: key);
   if (id == null || id.isEmpty) {

--- a/lib/services/notifications.dart
+++ b/lib/services/notifications.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 /// Thin wrapper over flutter_local_notifications for system notifications
@@ -10,16 +12,32 @@ class AppNotifications {
   static int _id = 100;
 
   static Future<void> init() async {
-    try {
-      const settings = InitializationSettings(
-        linux: LinuxInitializationSettings(defaultActionName: 'Open'),
-        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
-      );
-      await _plugin.initialize(settings);
-      _ready = true;
-    } catch (_) {
+    // On Linux, the plugin subscribes to a D-Bus signal stream as part of
+    // initialize(); when there's no session bus reachable at all (Steam Big
+    // Picture / gamescope, some minimal window managers — the same class of
+    // environment as issue #32), that subscription throws from inside a
+    // broadcast stream controller's listen callback, which escapes a normal
+    // try/catch around the await entirely. runZonedGuarded is the only way to
+    // catch that and keep notification init the best-effort it's meant to be.
+    final completer = Completer<void>();
+    runZonedGuarded(() async {
+      try {
+        const settings = InitializationSettings(
+          linux: LinuxInitializationSettings(defaultActionName: 'Open'),
+          android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+        );
+        await _plugin.initialize(settings);
+        _ready = true;
+      } catch (_) {
+        _ready = false;
+      } finally {
+        if (!completer.isCompleted) completer.complete();
+      }
+    }, (error, stack) {
       _ready = false;
-    }
+      if (!completer.isCompleted) completer.complete();
+    });
+    return completer.future;
   }
 
   /// Ask for the Android 13+ runtime notification permission. Without it, every

--- a/lib/services/resilient_secure_storage.dart
+++ b/lib/services/resilient_secure_storage.dart
@@ -1,0 +1,107 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// A drop-in [FlutterSecureStorage] replacement that transparently falls back
+/// to a local, unencrypted file when the platform's secret service is entirely
+/// unavailable, e.g. Steam Big Picture / gamescope on Linux, where there is no
+/// D-Bus secret service to activate at all (flutter_secure_storage throws
+/// "The name is not activatable" on every call). Without this, Fathom crashed
+/// before its first frame (issue #32): `_getOrCreateDeviceId` ran unguarded in
+/// `main()`, and the same secureStorageProvider backs login, saved passwords,
+/// and every other persisted setting throughout the app.
+///
+/// The fallback only engages after a real failure is observed, never for a
+/// working keyring, and then for the rest of the process, so a normal desktop
+/// session is unaffected. Values written while the fallback is active are NOT
+/// encrypted; they're kept in a plain JSON file under the app's support
+/// directory, the same tradeoff other desktop apps make when a platform gives
+/// them no keyring at all. It's a compatibility fallback for a genuinely
+/// absent keyring, not a general opt-out of security.
+class ResilientSecureStorage {
+  const ResilientSecureStorage();
+
+  static const _delegate = FlutterSecureStorage();
+
+  // Shared across every instance, so a failure discovered by one caller (say,
+  // main()'s device-id lookup) is immediately known to every other caller
+  // (every provider reading secureStorageProvider), instead of each one
+  // separately re-discovering the same D-Bus failure on its own first call.
+  static bool _secureBroken = false;
+  static Map<String, String>? _fallbackCache;
+
+  static Future<File> _fallbackFile() async {
+    final dir = await getApplicationSupportDirectory();
+    return File('${dir.path}/fathom_insecure_fallback.json');
+  }
+
+  static Future<Map<String, String>> _loadFallback() async {
+    final cached = _fallbackCache;
+    if (cached != null) return cached;
+    var map = <String, String>{};
+    try {
+      final file = await _fallbackFile();
+      if (file.existsSync()) {
+        final raw = jsonDecode(file.readAsStringSync());
+        if (raw is Map) map = raw.map((k, v) => MapEntry('$k', '$v'));
+      }
+    } catch (_) {}
+    return _fallbackCache = map;
+  }
+
+  static Future<void> _saveFallback(Map<String, String> map) async {
+    try {
+      final file = await _fallbackFile();
+      file.writeAsStringSync(jsonEncode(map));
+    } catch (_) {}
+  }
+
+  void _markBroken(Object error) {
+    if (_secureBroken) return;
+    _secureBroken = true;
+    debugPrint('[storage] system secret service unavailable ($error); '
+        'falling back to a local unencrypted store for this session');
+  }
+
+  Future<String?> read({required String key}) async {
+    if (!_secureBroken) {
+      try {
+        return await _delegate.read(key: key);
+      } catch (e) {
+        _markBroken(e);
+      }
+    }
+    final map = await _loadFallback();
+    return map[key];
+  }
+
+  Future<void> write({required String key, required String value}) async {
+    if (!_secureBroken) {
+      try {
+        await _delegate.write(key: key, value: value);
+        return;
+      } catch (e) {
+        _markBroken(e);
+      }
+    }
+    final map = await _loadFallback();
+    map[key] = value;
+    await _saveFallback(map);
+  }
+
+  Future<void> delete({required String key}) async {
+    if (!_secureBroken) {
+      try {
+        await _delegate.delete(key: key);
+        return;
+      } catch (e) {
+        _markBroken(e);
+      }
+    }
+    final map = await _loadFallback();
+    if (map.remove(key) != null) await _saveFallback(map);
+  }
+}

--- a/lib/services/tv_mode.dart
+++ b/lib/services/tv_mode.dart
@@ -3,7 +3,8 @@ import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/services.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import 'resilient_secure_storage.dart';
 
 /// Whether the app is running on an Android TV (leanback) device — i.e. driven
 /// by a D-pad remote with no touchscreen. Set once at startup by [detectTvMode]
@@ -34,7 +35,7 @@ Future<void> detectTvMode() async {
 Future<void> applyForcedTvMode() async {
   if (isTvDevice) return;
   try {
-    const raw = FlutterSecureStorage();
+    const raw = ResilientSecureStorage();
     final s = await raw.read(key: 'fathom_prefs');
     if (s == null) return;
     final json = jsonDecode(s) as Map<String, dynamic>;

--- a/lib/state/providers.dart
+++ b/lib/state/providers.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../api/jellyfin_client.dart';
+import '../services/resilient_secure_storage.dart';
 
 /// A stable per-install device id. Overridden in `main()` with the real value
 /// read from secure storage before the app starts.
@@ -9,8 +9,8 @@ final deviceIdProvider = Provider<String>((ref) {
   throw UnimplementedError('deviceIdProvider must be overridden in main()');
 });
 
-final secureStorageProvider = Provider<FlutterSecureStorage>((ref) {
-  return const FlutterSecureStorage();
+final secureStorageProvider = Provider<ResilientSecureStorage>((ref) {
+  return const ResilientSecureStorage();
 });
 
 final jellyfinClientProvider = Provider<JellyfinClient>((ref) {

--- a/test/download_state_test.dart
+++ b/test/download_state_test.dart
@@ -3,29 +3,31 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:fathom/models/youtube_video.dart';
+import 'package:fathom/services/resilient_secure_storage.dart';
 import 'package:fathom/services/youtube_download.dart';
 import 'package:fathom/state/providers.dart';
 import 'package:fathom/state/youtube_providers.dart';
 
-class _FakeStorage implements FlutterSecureStorage {
+class _FakeStorage implements ResilientSecureStorage {
   final Map<String, String> store = {};
   @override
-  Future<String?> read({required String key, dynamic iOptions, dynamic aOptions, dynamic lOptions, dynamic webOptions, dynamic mOptions, dynamic wOptions}) async {
+  Future<String?> read({required String key}) async {
     // Storage is slow in reality (a keyring round-trip). The delay is the
     // point: it makes build() finish after start() has already set state.
     await Future<void>.delayed(const Duration(milliseconds: 50));
     return store[key];
   }
   @override
-  Future<void> write({required String key, required String? value, dynamic iOptions, dynamic aOptions, dynamic lOptions, dynamic webOptions, dynamic mOptions, dynamic wOptions}) async {
-    if (value != null) store[key] = value;
+  Future<void> write({required String key, required String value}) async {
+    store[key] = value;
   }
   @override
-  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
+  Future<void> delete({required String key}) async {
+    store.remove(key);
+  }
 }
 
 /// Never finishes, so the download stays "in progress" like a real one.

--- a/test/feed_group_test.dart
+++ b/test/feed_group_test.dart
@@ -1,29 +1,26 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:fathom/models/youtube_channel.dart';
+import 'package:fathom/services/resilient_secure_storage.dart';
 import 'package:fathom/state/providers.dart';
 import 'package:fathom/state/youtube_providers.dart';
 
-class _FakeStorage implements FlutterSecureStorage {
+class _FakeStorage implements ResilientSecureStorage {
   final Map<String, String> store = {};
 
   @override
-  Future<String?> read({required String key, dynamic iOptions, dynamic aOptions, dynamic lOptions, dynamic webOptions, dynamic mOptions, dynamic wOptions}) async =>
-      store[key];
+  Future<String?> read({required String key}) async => store[key];
 
   @override
-  Future<void> write({required String key, required String? value, dynamic iOptions, dynamic aOptions, dynamic lOptions, dynamic webOptions, dynamic mOptions, dynamic wOptions}) async {
-    if (value == null) {
-      store.remove(key);
-    } else {
-      store[key] = value;
-    }
+  Future<void> write({required String key, required String value}) async {
+    store[key] = value;
   }
 
   @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+  Future<void> delete({required String key}) async {
+    store.remove(key);
+  }
 }
 
 void main() {

--- a/test/search_history_test.dart
+++ b/test/search_history_test.dart
@@ -1,29 +1,26 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:fathom/services/resilient_secure_storage.dart';
 import 'package:fathom/state/providers.dart';
 import 'package:fathom/state/youtube_providers.dart';
 
 /// In-memory stand-in so tests don't touch the real keyring.
-class _FakeStorage implements FlutterSecureStorage {
+class _FakeStorage implements ResilientSecureStorage {
   final Map<String, String> store = {};
 
   @override
-  Future<String?> read({required String key, dynamic iOptions, dynamic aOptions, dynamic lOptions, dynamic webOptions, dynamic mOptions, dynamic wOptions}) async =>
-      store[key];
+  Future<String?> read({required String key}) async => store[key];
 
   @override
-  Future<void> write({required String key, required String? value, dynamic iOptions, dynamic aOptions, dynamic lOptions, dynamic webOptions, dynamic mOptions, dynamic wOptions}) async {
-    if (value == null) {
-      store.remove(key);
-    } else {
-      store[key] = value;
-    }
+  Future<void> write({required String key, required String value}) async {
+    store[key] = value;
   }
 
   @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+  Future<void> delete({required String key}) async {
+    store.remove(key);
+  }
 }
 
 void main() {


### PR DESCRIPTION
Fixes #32. `_getOrCreateDeviceId` ran unguarded in `main()` before the widget tree existed, so a libsecret failure (no D-Bus secret service at all, e.g. Steam Big Picture / gamescope) crashed the app before its first frame. `secureStorageProvider` now returns a resilient wrapper that transparently falls back to a local plain-text file after a genuine failure, never when the keyring works normally, fixing the crash and every other secure-storage-backed feature in the same environments. Also hardens `AppNotifications.init()` against the same class of failure via `runZonedGuarded` (a Zone-guarded D-Bus stream error was escaping its own try/catch). Verified against a real reproduction with `DBUS_SESSION_BUS_ADDRESS` pointed at a nonexistent socket.