### PR TITLE
Docs: fresh version/star/download badges on the homepage, authenticate repo-stats fetch, refresh stale version examples

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,4 +38,10 @@ jobs:
           git config user.name "thebigjoe1"
           git config user.email "26659217+thebigjoe1@users.noreply.github.com"
       - name: Build and publish to gh-pages
+        # GITHUB_TOKEN lets mkdocs-material authenticate its repo stats (stars/
+        # forks) fetch; without it the unauthenticated call hits GitHub's low
+        # per-IP rate limit on shared Actions runners and silently degrades to
+        # showing the repo name with no counts.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mkdocs gh-deploy --force --strict

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,11 @@
 
 **Dive into your media.**
 
+[![Latest release](https://img.shields.io/github/v/release/Fathom-Media/fathom)](https://github.com/Fathom-Media/fathom/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/Fathom-Media/fathom/total)](https://github.com/Fathom-Media/fathom/releases)
+[![Stars](https://img.shields.io/github/stars/Fathom-Media/fathom)](https://github.com/Fathom-Media/fathom/stargazers)
+[![License](https://img.shields.io/github/license/Fathom-Media/fathom?color=blue)](https://github.com/Fathom-Media/fathom/blob/main/LICENSE)
+
 Fathom is an all-in-one client for [Jellyfin](https://jellyfin.org), on desktop and Android. It brings your whole setup into one window: movies, shows, music, and Live TV, plus most of Jellyfin's server-side management, so you rarely need the web dashboard. Two optional integrations, [Seerr](features.md#requests-ratings-and-watch-together) requests and a full [YouTube](youtube.md) client, live right inside the app.
 
 Everything plays through mpv (via [media_kit](https://github.com/media-kit/media-kit) / libmpv), so you get direct play, hardware decoding, and real subtitle and audio track control.

--- a/docs/install.md
+++ b/docs/install.md
@@ -39,7 +39,7 @@ Download **`Fathom-windows-x64.zip`**, extract it, and run `fathom.exe`. It is s
 
 ## Android
 
-Download the APK from [Releases](https://github.com/Fathom-Media/fathom/releases) (named like `Fathom-0.11.0.apk`) and open it. Android asks you to allow installing unknown apps the first time; grant it and confirm. Fathom runs on phones and tablets, and on Android TV, where the interface is D-pad friendly. Android TV support is experimental for now and still being refined.
+Download the APK from [Releases](https://github.com/Fathom-Media/fathom/releases) (named like `Fathom-0.12.0.apk`) and open it. Android asks you to allow installing unknown apps the first time; grant it and confirm. Fathom runs on phones and tablets, and on Android TV, where the interface is D-pad friendly. Android TV support is experimental for now and still being refined.
 
 After that, Fathom keeps itself up to date from **Settings → Updates**: it downloads the new APK and hands it to the system installer for you to confirm. Pick the **Dev** channel there if you want the pre-release test builds.
 

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -2,21 +2,21 @@
 
 Fathom updates itself. On Linux it swaps the AppImage in place and relaunches; on Windows it replaces the portable build and relaunches; on Android it downloads the APK and hands it to the system installer (you confirm the prompt, granting "install unknown apps" the first time). You can also just download a newer build from [Releases](https://github.com/Fathom-Media/fathom/releases) at any time.
 
-Open **Settings → Updates** to check manually, choose a channel, and toggle checking on startup.
+Open **Settings → Updates** to check manually, choose a channel, and turn automatic checking on or off. When it is on, pick how often it checks: every launch, daily, or weekly (a daily or weekly check also runs in the background while the app stays open, so you do not have to relaunch to pick it up).
 
 ## Channels
 
 | Channel | What you get |
 | --- | --- |
-| **Stable** | Only full releases (for example `0.10.0`). The default. |
+| **Stable** | Only full releases (for example `0.12.0`). The default. |
 | **Dev** | Full releases plus pre-release test builds, so you get new features and fixes early. |
 
-The updater always offers the newest version for your channel and downloads the build that matches your platform and CPU architecture automatically (x86_64 vs aarch64 on Linux; a universal APK on Android).
+The updater always offers the newest version for your channel and downloads the build that matches your platform and CPU architecture automatically (x86_64 vs aarch64 on Linux; a universal APK on Android). When a new build is found, Fathom shows a dismissible banner and, on Linux and Android, a native system notification.
 
 ## How versions work
 
-- **Stable releases** are plain versions like `0.10.0`.
-- **Dev builds** are pre-releases named `0.11.0-dev01`, `0.11.0-dev02`, and so on. The Dev channel tracks these in order and rolls you onto the next stable release when it lands.
+- **Stable releases** are plain versions like `0.12.0`.
+- **Dev builds** are pre-releases named `0.12.0-dev01`, `0.12.0-dev02`, and so on. The Dev channel tracks these in order and rolls you onto the next stable release when it lands.
 - A floating **`dev-latest`** pre-release always points at the newest dev build, as a stable download link. The in-app updater tracks the numbered builds, not this alias.
 
 !!! note "Safe by design"


### PR DESCRIPTION
Re-promotes the docs fix to main (approved), after the earlier revert also undid it as a side effect.